### PR TITLE
Update Spec link to open in a new tab

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -30,7 +30,7 @@
     { href: '/validator/', label: 'Validator' },
     { href: '/learn/', label: 'Learn' },
     { href: '/community/', label: 'Community' },
-    { href: 'https://github.com/ucan-wg/spec', label: 'Spec' },
+    { href: 'https://github.com/ucan-wg/spec', label: 'Spec', outbound: true },
     { href: '/about/', label: 'About' }
   ]
 
@@ -63,7 +63,11 @@
 
   <HeaderNav>
     {#each siteNavMap as link}
-      <HeaderNavItem href={link.href} text={link.label} />
+      {#if link.outbound}
+        <HeaderNavItem href={link.href} text={link.label} target="_blank" />
+      {:else}
+        <HeaderNavItem href={link.href} text={link.label} />
+      {/if}
     {/each}
   </HeaderNav>
 


### PR DESCRIPTION
# Description

This PR updates the Spec link in the header to open in a new tab.

## Link to issue

Closes #44 

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Test plan (required)

Run the site and check that the Spec link in the header opens in a new tab.

## Screenshots/Screencaps

![CleanShot 2022-12-16 at 14 38 28](https://user-images.githubusercontent.com/7957636/208200454-b2dd283c-3988-4131-bc42-086b53342929.gif)

