### PR TITLE
Update links to learning and community resources

### DIFF
--- a/src/routes/community/+page.md
+++ b/src/routes/community/+page.md
@@ -9,8 +9,9 @@
 
 # Community
 
-- <OutboundLink href="https://github.com/ucan-wg/spec/discussions">GitHub Discussions</OutboundLink>
-- <OutboundLink href="https://fission.codes/discord">Join the Fission Discord Server</OutboundLink>
+- <OutboundLink href="https://github.com/ucan-wg/spec/discussions">UCAN Discussions</OutboundLink>
+- <OutboundLink href="https://discord.gg/zSfgeHhKxA">UCAN Discord Server</OutboundLink>
+- <OutboundLink href="https://lu.ma/ucan">UCAN Community Call</OutboundLink>
 
 ## Libraries
   

--- a/src/routes/learn/+page.md
+++ b/src/routes/learn/+page.md
@@ -70,11 +70,8 @@ Typescript:
 
 ### Next steps
 
- * <OutboundLink href="https://github.com/ucan-wg/ts-ucan">`ucans` library github repository</OutboundLink>
- * <OutboundLink href="https://github.com/ucan-wg/spec">ucan spec repository</OutboundLink>
- * <OutboundLink href="https://whitepaper.fission.codes/authorization/id-overview">Fission Whitepaper</OutboundLink>
-
- If you are using ucans in your work and have ideas for improvement, please consider adding any ideas for improvement to the UCAN Improvement Proposal repository: <OutboundLink href="https://github.com/ucan-wg/UIPs">github.com/ucan-wg/UIPs</OutboundLink>
+ * Visit the <OutboundLink href="https://github.com/ucan-wg/">UCAN Working Group organization</OutboundLink> to view libraries and specifications
+ * Read the core <OutboundLink href="https://github.com/ucan-wg/spec">UCAN specification</OutboundLink>
 
 </div>
 


### PR DESCRIPTION
This PR makes the following changes:

- [x] Remove note and link to UIPs repo. We briefly had a repository for improvement proposals, but it no longer exists.
- [x] Direct learners to GH working group where they can find multiple implementations
- [x] Remove link to the Fission Whitepaper
- [x] Link to the UCAN Discord server instead of the Fission Discord server
- [x] Add a link to the UCAN community call