### PR TITLE
Add usage examples to homepage

### DIFF
--- a/src/routes/+page.md
+++ b/src/routes/+page.md
@@ -37,8 +37,9 @@ UCANs are all you need to sign into multiple machines, delegate access for servi
 We are making this available as a building block for developers to solve user authorization and delegation within their own applications.
 
 UCANs are used by:
-- [Web3.storage](https://web3.storage/), for delegating access to decentralized storage for thousands of developers ([blog post](https://blog.web3.storage/posts/intro-to-ucan))
-- [WNFS](https://guide.fission.codes/developers/webnative/file-system-wnfs), for access to mutable resources ([forum post](https://talk.fission.codes/t/ucans-wnfs-and-ipfs-security-broadly/1312))
+- [Storacha](https://storacha.network) (previously web3.storage), for delegating access to decentralized storage for thousands of developers ([blog post](https://blog.web3.storage/posts/intro-to-ucan))
+- [ODD SDK](https://github.com/oddsdk/ts-odd)), for access to mutable resources
+- [Awake](https://github.com/ucan-wg/awake), a mutually authenticating AKE (authenticated key exchange) for p2p applications
 - Magazine publishers, to authorize discounts across business units for millions of subscribers
 
 <h2>The UCAN data structure</h2>

--- a/src/routes/+page.md
+++ b/src/routes/+page.md
@@ -34,7 +34,12 @@ This setup has several advantages:
 
 UCANs are all you need to sign into multiple machines, delegate access for service providers to do things while you are offline, securely collaborate on documents with a team, and more. You get the flexibility of fine- or coarse-grained control, all controlled by the one who cares about the data the most: the user.
 
-We've implemented this as the authorization system for Fission, and are also making this available as a building block for developers to solve user authorization and delegation within their own applications.
+We are making this available as a building block for developers to solve user authorization and delegation within their own applications.
+
+UCANs are used by:
+- [Web3.storage](https://web3.storage/), for delegating access to decentralized storage for thousands of developers ([blog post](https://blog.web3.storage/posts/intro-to-ucan))
+- [WNFS](https://guide.fission.codes/developers/webnative/file-system-wnfs), for access to mutable resources ([forum post](https://talk.fission.codes/t/ucans-wnfs-and-ipfs-security-broadly/1312))
+- Magazine publishers, to authorize discounts across business units for millions of subscribers
 
 <h2>The UCAN data structure</h2>
 


### PR DESCRIPTION
I think adding some usage examples (with some hints at scale/hardening) may help with credibility and convincing for people researching & evaluating UCANs for their projects. I know there's a larger redesign planned (mentioned in #77) but this content should still be relevant.

Sending a PR to make this suggestion more concrete. I won't be offended if this is closed, or if rewrites are committed directly.